### PR TITLE
Sort imported modules using isort

### DIFF
--- a/SwiftNameDemangler.py
+++ b/SwiftNameDemangler.py
@@ -6,10 +6,12 @@
 # Requires Swift to be installed on the machine
 # Takes some time to run for larger applications
 
+import subprocess
+
 from ghidra.program.model.listing import Function
 from ghidra.program.model.symbol import SymbolType
 from java.lang import System
-import subprocess
+
 
 def demangle_swift_name(mangled_name):
     os_name = System.getProperty("os.name").lower()

--- a/SwizzlingDetector.py
+++ b/SwizzlingDetector.py
@@ -4,6 +4,7 @@
 
 from ghidra.program.model.symbol import SymbolType
 
+
 def find_swizzling():
     # List of potential swizzling related methods
     swizzling_methods = [


### PR DESCRIPTION
So it's easier to read :-)

Minor changes:
```
$ isort .
```

https://pycqa.github.io/isort/